### PR TITLE
MNT: ignore .vsm files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ _CompileInfo
 *.sw[op]
 *.tmcRefac
 *.tpy
+*.vsm
 *.~u
 *~
 .pytmc_build


### PR DESCRIPTION
## Description
add .vsm files to gitignore

## Motivation and Context
The .vsm file just hold file tree expansion settings and a reference to the most recent user's file system.  This isn't necessary or helpful.  

## How Has This Been Tested?
N/A

## Where Has This Been Documented?
This PR.

## Screenshots (if appropriate):

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive comments
- [x] Test suite passes locally
- [x] Libraries are set to fixed versions and not ``Always Newest``
- [x] Code committed with ``pre-commit`` (alternatively ``pre-commit run --all-files``)
